### PR TITLE
Use hiltViewModel for CardStack screen

### DIFF
--- a/app/src/main/java/com/hanto/styleanalyzer/presentation/ui/cardstack/CardStackTestScreen.kt
+++ b/app/src/main/java/com/hanto/styleanalyzer/presentation/ui/cardstack/CardStackTestScreen.kt
@@ -45,13 +45,14 @@ import com.hanto.styleanalyzer.presentation.ui.common.cardstack.DragAlignment
 import com.hanto.styleanalyzer.presentation.ui.common.cardstack.DraggableCardStack
 import com.hanto.styleanalyzer.presentation.ui.theme.MinimalColors
 import com.hanto.styleanalyzer.presentation.viewmodel.StyleTestViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun CardStackTestScreen(
     modifier: Modifier = Modifier,
-    viewModel: StyleTestViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+    viewModel: StyleTestViewModel = hiltViewModel()
 ) {
     val currentItems = viewModel.displayItems
     val currentSession = viewModel.currentSession


### PR DESCRIPTION
## Summary
- use `hiltViewModel` in `CardStackTestScreen` for Hilt injection

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b74292c832da481e482aa4190dc