### PR TITLE
Remove item field from SwipeAction and adjust ViewModel

### DIFF
--- a/app/src/main/java/com/hanto/styleanalyzer/domain/model/DataModels.kt
+++ b/app/src/main/java/com/hanto/styleanalyzer/domain/model/DataModels.kt
@@ -107,7 +107,6 @@ enum class SwipeType {
 data class SwipeAction(
     val id: String = generateActionId(),
     val itemId: String,
-    val item: FashionItem,
     val action: SwipeType,
     val sessionId: String,
     val timestamp: Long = System.currentTimeMillis()

--- a/app/src/main/java/com/hanto/styleanalyzer/presentation/viewmodel/StyleTestViewModel.kt
+++ b/app/src/main/java/com/hanto/styleanalyzer/presentation/viewmodel/StyleTestViewModel.kt
@@ -58,7 +58,7 @@ class StyleTestViewModel @Inject constructor() : ViewModel() {
     fun onSwipeRight(item: FashionItem) {
         Log.d(TAG, "좋아요 스와이프 - 아이템: ${item.description} (ID: ${item.id})")
         Log.d(TAG, "스와이프 전 남은 아이템 수: ${displayItems.size}")
-        processSwipeAction(item, SwipeType.LIKE)
+        processSwipeAction(item.id, SwipeType.LIKE)
         Log.d(TAG, "스와이프 후 남은 아이템 수: ${displayItems.size}")
     }
 
@@ -68,24 +68,27 @@ class StyleTestViewModel @Inject constructor() : ViewModel() {
     fun onSwipeLeft(item: FashionItem) {
         Log.d(TAG, "싫어요 스와이프 - 아이템: ${item.description} (ID: ${item.id})")
         Log.d(TAG, "스와이프 전 남은 아이템 수: ${displayItems.size}")
-        processSwipeAction(item, SwipeType.DISLIKE)
+        processSwipeAction(item.id, SwipeType.DISLIKE)
         Log.d(TAG, "스와이프 후 남은 아이템 수: ${displayItems.size}")
     }
 
     /**
      * 스와이프 액션 처리 - 개선된 로직 및 로깅
      */
-    private fun processSwipeAction(item: FashionItem, action: SwipeType) {
+    private fun processSwipeAction(itemId: String, action: SwipeType) {
         try {
             // 현재 상태 로그
             Log.d(TAG, "processSwipeAction 시작")
-            Log.d(TAG, "처리할 아이템 ID: ${item.id}")
+            Log.d(TAG, "처리할 아이템 ID: $itemId")
             Log.d(TAG, "현재 displayItems: ${displayItems.map { "${it.id}-${it.description}" }}")
+
+            val item = displayItems.find { it.id == itemId }
+                ?: throw IllegalArgumentException("Item not found: $itemId")
+            Log.d(TAG, "처리할 아이템: ${item.description}")
 
             // 스와이프 액션 생성
             val swipeAction = SwipeAction(
-                itemId = item.id,
-                item = item,
+                itemId = itemId,
                 action = action,
                 sessionId = currentSession.sessionId
             )
@@ -95,9 +98,7 @@ class StyleTestViewModel @Inject constructor() : ViewModel() {
                 swipeActions = currentSession.swipeActions + swipeAction
             )
 
-            val itemsBeforeRemoval = displayItems.size
-            displayItems = displayItems.filterNot { it.id == item.id }
-            val itemsAfterRemoval = displayItems.size
+            displayItems = displayItems.filterNot { it.id == itemId }
 
             // 완료 상태 체크
             if (displayItems.isEmpty()) {

--- a/app/src/test/java/com/hanto/styleanalyzer/domain/model/SwipeActionSerializationTest.kt
+++ b/app/src/test/java/com/hanto/styleanalyzer/domain/model/SwipeActionSerializationTest.kt
@@ -1,0 +1,22 @@
+package com.hanto.styleanalyzer.domain.model
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SwipeActionSerializationTest {
+    @Test
+    fun swipeAction_serializesAndDeserializes() {
+        val original = SwipeAction(
+            id = "action1",
+            itemId = "item1",
+            action = SwipeType.LIKE,
+            sessionId = "session1",
+            timestamp = 123456789L
+        )
+        val gson = Gson()
+        val json = gson.toJson(original)
+        val restored = gson.fromJson(json, SwipeAction::class.java)
+        assertEquals(original, restored)
+    }
+}


### PR DESCRIPTION
## Summary
- drop `FashionItem` reference from `SwipeAction` to keep only `itemId`
- lookup items by `itemId` when processing swipes in `StyleTestViewModel`
- add Gson-based test ensuring `SwipeAction` serializes and deserializes correctly

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68ba4b73f61c832da7d9a7aab2c23efb